### PR TITLE
Fix 'fetch' not being able to find an item at all, and 'update' not being able to ever update

### DIFF
--- a/YamlDataSource.js
+++ b/YamlDataSource.js
@@ -62,11 +62,13 @@ class YamlDataSource extends FileDataSource {
   async update(config = {}, id, data) {
     const currentData = await this.fetchAll(config);
 
-    if (Array.isArray(currentData)) {
-      throw new TypeError('Yaml data stored as array, cannot update by id');
+    const fetchIndex = currentData.findIndex(item => item.id === id);
+
+    if(fetchIndex === -1) {
+      throw new ReferenceError(`Record with id [${id}] not found.`);
     }
 
-    currentData[id] = data;
+    currentData[fetchIndex] = data;
 
     return this.replace(config, currentData);
   }

--- a/YamlDataSource.js
+++ b/YamlDataSource.js
@@ -37,12 +37,14 @@ class YamlDataSource extends FileDataSource {
   async fetch(config = {}, id) {
     const data = await this.fetchAll(config);
 
-    if (!data.hasOwnProperty(id)) {
+    const fetchSingleItem = data.find(item => item.id === id);
+
+    if (!fetchSingleItem) {
       throw new ReferenceError(`Record with id [${id}] not found.`);
     }
 
-    return data[id];
-  }
+    return fetchSingleItem;
+}
 
   replace(config = {}, data) {
     const filepath = this.resolvePath(config);

--- a/YamlDataSource.js
+++ b/YamlDataSource.js
@@ -65,7 +65,7 @@ class YamlDataSource extends FileDataSource {
     const fetchIndex = currentData.findIndex(item => item.id === id);
 
     if(fetchIndex === -1) {
-      throw new ReferenceError(`Record with id [${id}] not found.`);
+      throw new ReferenceError(`Record with id [${id}] not found, no changes were made.`);
     }
 
     currentData[fetchIndex] = data;


### PR DESCRIPTION
So, this fixes a fairly peculiar issue with the `fetch` method.

The `const data = await this.fetchAll(config);` method returns an `Array`, and the old code used `hasOwnProperty`, which is meant for objects. That meant the code would always return false, and whatever the engine was looking for would never be found.

After a bit of brainstorming with Sean, we figured it out. I changed it to a `find` method, instead, and it works like a charm.

My bundle, [Wvnder](https://github.com/NamelessFaceless/Wvnder) -- A OLC system I'm working on, depends on these changes. There may be more to come, since I've only patched up the YAML sources for the Rooms for the time being.