### PR TITLE
normalize resolvePath return value based on OS

### DIFF
--- a/FileDataSource.js
+++ b/FileDataSource.js
@@ -33,7 +33,7 @@ class FileDataSource {
       throw new Error('No bundle configured for path with [BUNDLE]');
     }
 
-    return this.root + '/' + path
+    return require('path').join(this.root, path)
       .replace('[AREA]', area)
       .replace('[BUNDLE]', bundle)
     ;


### PR DESCRIPTION
This fixes an issue where the concatenated path returned from `FileDataSource.resolvePath` isn't normalized on Windows platforms. Node normalizes these internally, but we can run into issues if we try and use the string explicitly elsewhere, such as in `JsonDataSource.fetchAll`:

```js
delete require.cache[filepath];

return Promise.resolve(require(filepath));
```

In this case, the effect is that the deletion misses, and `require` will always return the cached value. This can lead to issues like player save data being rolled back upon subsequent logins.